### PR TITLE
Fix setting environment variable example

### DIFF
--- a/docs/source/main.rst
+++ b/docs/source/main.rst
@@ -836,7 +836,7 @@ Then set the :bash:`MY_CONFIG` environment variable, by running
 
 .. code-block:: bash
 
-    gigalixir set_config MY_CONFIG foo
+    gigalixir set_config $APP_NAME MY_CONFIG foo
 
 In your app code, access the environment variable using 
 


### PR DESCRIPTION
There appeared to be a typo on the example around setting environment variables. I have changed;
```
 gigalixir set_config MY_CONFIG foo
```
to; 
```
 gigalixir set_config $APP_NAME MY_CONFIG foo
```