### PR TITLE
Fixes NoneType object bug

### DIFF
--- a/gigalixir/__init__.py
+++ b/gigalixir/__init__.py
@@ -740,6 +740,7 @@ def delete_config(ctx, app_name, key):
 @click.argument('email')
 @click.pass_context
 @report_errors
+@detect_app_name
 def add_permission(ctx, app_name, email):
     """
     Grants a user permission to deploy an app.


### PR DESCRIPTION
If a user goes to do `gigalixir access:add <email_here>`, they get the error `'NoneType' object has no attribute 'encode'`. If a user does `gigalixir access:add <email_here> -a <name_of_app>`, the command will succeed. Even if the other commands don't need the explicit app name because it is already set, this one seemed to. Adding the `@detect_app_name` decorator does in fact fix it. 