### PR TITLE
Fix outdated region references and fix typo

### DIFF
--- a/docs/source/main.rst
+++ b/docs/source/main.rst
@@ -730,11 +730,11 @@ Known Issues
 Can I run my app in AWS instead of Google Cloud Platform? What about Europe?
 ============================================================================
 
-Yes, if your current infrastructure is on AWS, you'll probably want to run your gigalixir app on AWS too. Or if most of your users are in Europe, you probably want to host your app in Europe. We currently support GCP us-central1 and GCP europe-west1 as well as AWS us-east-1 and AWS us-west-2. When creating your app with :bash:`gigalixir create` simply specify the :bash:`--cloud=aws` and :bash:`--region=us-east-1` options.
+Yes, if your current infrastructure is on AWS, you'll probably want to run your gigalixir app on AWS too. Or if most of your users are in Europe, you probably want to host your app in Europe. We currently support GCP v2018-us-central1 and GCP europe-west1 as well as AWS us-east-1 and AWS us-west-2. When creating your app with :bash:`gigalixir create` simply specify the :bash:`--cloud=aws` and :bash:`--region=us-east-1` options.
 
 Once the app is created, it's difficult to migrate to another region. If you want to do this, Heroku's guide is a good overview of what you should consider. If you don't mind downtime, the transition could be easy, but unfortunately gigalixir isn't able to do it for you with a button press. See https://devcenter.heroku.com/articles/app-migration
 
-One thing to keep in mind is that Gigalixir Postgres databases are as o right now only available in GCP/v2018-us-central1 so if you plan to use a Gigalixir-managed database, make sure your app lives in the default cloud and region.
+One thing to keep in mind is that Gigalixir Postgres databases are as of right now only available in GCP/v2018-us-central1 so if you plan to use a Gigalixir-managed database, make sure your app lives in the default cloud and region.
 
 If you don't see the region you want, please `contact us`_ and let us know. We open new regions based purely on demand.
 
@@ -2754,7 +2754,7 @@ Indices and Tables
 .. _`PaperTrail`: https://papertrailapp.com/
 .. _`Running Elixir and Phoenix projects on a cluster of nodes`: https://dockyard.com/blog/2016/01/28/running-elixir-and-phoenix-projects-on-a-cluster-of-nodes
 .. |signup details| replace:: Create an account using the following command. It will prompt you for your email address and password. You will have to confirm your email before continuing. Gigalixir's free tier does not require a credit card, but you will be limited to 1 instance with 0.2GB of memory and 1 postgresql database limited to 10,000 rows.
-.. |set up app for deploys| replace:: To create your app, run the following command. It will also set up a git remote. This must be run from within a git repository folder. An app name will be generated for you, but you can also optionally supply an app name if you wish using :bash:`gigalixir create -n $APP_NAME`. There is currently no way to change your app name once it is created. If you like, you can also choose which cloud provider and region using the :bash:`--cloud` and :bash:`--region` options. We currently support :bash:`gcp` in :bash:`us-central1` or :bash:`europe-west1` and :bash:`aws` in :bash:`us-east-1` or :bash:`us-west-2`.
+.. |set up app for deploys| replace:: To create your app, run the following command. It will also set up a git remote. This must be run from within a git repository folder. An app name will be generated for you, but you can also optionally supply an app name if you wish using :bash:`gigalixir create -n $APP_NAME`. There is currently no way to change your app name once it is created. If you like, you can also choose which cloud provider and region using the :bash:`--cloud` and :bash:`--region` options. We currently support :bash:`gcp` in :bash:`v2018-us-central1` or :bash:`europe-west1` and :bash:`aws` in :bash:`us-east-1` or :bash:`us-west-2`.
 .. _`The Twelve-Factor App's Config Factor`: https://12factor.net/config
 .. _`Herokuish`: https://github.com/gliderlabs/herokuish
 .. _`gigalixir-getting-started`: https://github.com/gigalixir/gigalixir-getting-started


### PR DESCRIPTION
It's technically still possible to create an app in the old `us-central1` region if you specify with the flag, so this update just makes sure that the default region `v2018-us-central1` is in the docs for anyone who uses the flag.

I also noticed a (very) small type so I threw a correction in here.