### PR TITLE
Windows support

### DIFF
--- a/gigalixir/__init__.py
+++ b/gigalixir/__init__.py
@@ -1,8 +1,10 @@
 from .shell import cast, call
 from .routers.linux import LinuxRouter
 from .routers.darwin import DarwinRouter
+from .routers.windows import WindowsRouter
 from .openers.linux import LinuxOpener
 from .openers.darwin import DarwinOpener
+from .openers.windows import WindowsOpener
 from . import observer as gigalixir_observer
 from . import user as gigalixir_user
 from . import app as gigalixir_app
@@ -19,7 +21,7 @@ from . import usage as gigalixir_usage
 from . import database as gigalixir_database
 from . import free_database as gigalixir_free_database
 from . import canary as gigalixir_canary
-from . import git
+#from . import git
 import click
 import requests
 import getpass
@@ -33,6 +35,7 @@ import logging
 import json
 import netrc
 import os
+import platform
 from functools import wraps
 import pkg_resources
 
@@ -185,7 +188,7 @@ class AliasedGroup(click.Group):
 
 def detect_app():
     try:
-        git.check_for_git()
+        #git.check_for_git()
         remote = call("git remote -v")
         # matches first instance of
         # git.gigalixir.com/foo.git
@@ -220,13 +223,20 @@ def cli(ctx, env):
 
     ctx.obj['host'] = host
 
-    PLATFORM = call("uname -s").lower() # linux or darwin
+    PLATFORM = platform.system().lower() # linux, darwin, or windows
     if PLATFORM == "linux":
         ctx.obj['router'] = LinuxRouter()
         ctx.obj['opener'] = LinuxOpener()
     elif PLATFORM == "darwin":
         ctx.obj['router'] = DarwinRouter()
         ctx.obj['opener'] = DarwinOpener()
+    elif PLATFORM == "windows":
+        try:
+            os.environ['HOME']
+        except KeyError:
+            os.environ['HOME'] = os.environ['USERPROFILE']
+        ctx.obj['router'] = WindowsRouter()
+        ctx.obj['opener'] = WindowsOpener()
     else:
         raise Exception("Unknown platform: %s" % PLATFORM)
 

--- a/gigalixir/__init__.py
+++ b/gigalixir/__init__.py
@@ -21,7 +21,7 @@ from . import usage as gigalixir_usage
 from . import database as gigalixir_database
 from . import free_database as gigalixir_free_database
 from . import canary as gigalixir_canary
-#from . import git
+from . import git
 import click
 import requests
 import getpass
@@ -188,7 +188,7 @@ class AliasedGroup(click.Group):
 
 def detect_app():
     try:
-        #git.check_for_git()
+        git.check_for_git()
         remote = call("git remote -v")
         # matches first instance of
         # git.gigalixir.com/foo.git

--- a/gigalixir/api_key.py
+++ b/gigalixir/api_key.py
@@ -13,7 +13,7 @@ def regenerate(host, email, password, yes):
         raise Exception(r.text)
     else:
         key = json.loads(r.text)["data"]["key"]
-        if yes or click.confirm('Would you like to save your api key to your ~/.netrc file?'):
+        if yes or click.confirm('Would you like to save your api key to your ~/%s file?' % netrc.netrc_name()):
             netrc.update_netrc(email, key)
         else:
             logging.getLogger("gigalixir-cli").info('Your api key is %s' % key)

--- a/gigalixir/app.py
+++ b/gigalixir/app.py
@@ -10,7 +10,7 @@ from .shell import cast, call
 from . import auth
 from . import presenter
 from . import ssh_key
-from . import git
+#from . import git
 from contextlib import closing
 from six.moves.urllib.parse import quote
 
@@ -39,7 +39,7 @@ def info(host, app_name):
         presenter.echo_json(data)
 
 def set_git_remote(host, app_name):
-    git.check_for_git()
+    #git.check_for_git()
 
     remotes = call('git remote').splitlines()
     if 'gigalixir' in remotes:
@@ -48,7 +48,7 @@ def set_git_remote(host, app_name):
     logging.getLogger("gigalixir-cli").info("Set git remote: gigalixir.")
 
 def create(host, unique_name, cloud, region, stack):
-    git.check_for_git()
+    #git.check_for_git()
 
     body = {}
     if unique_name != None:

--- a/gigalixir/app.py
+++ b/gigalixir/app.py
@@ -10,7 +10,7 @@ from .shell import cast, call
 from . import auth
 from . import presenter
 from . import ssh_key
-#from . import git
+from . import git
 from contextlib import closing
 from six.moves.urllib.parse import quote
 
@@ -39,7 +39,7 @@ def info(host, app_name):
         presenter.echo_json(data)
 
 def set_git_remote(host, app_name):
-    #git.check_for_git()
+    git.check_for_git()
 
     remotes = call('git remote').splitlines()
     if 'gigalixir' in remotes:
@@ -48,7 +48,7 @@ def set_git_remote(host, app_name):
     logging.getLogger("gigalixir-cli").info("Set git remote: gigalixir.")
 
 def create(host, unique_name, cloud, region, stack):
-    #git.check_for_git()
+    git.check_for_git()
 
     body = {}
     if unique_name != None:

--- a/gigalixir/netrc.py
+++ b/gigalixir/netrc.py
@@ -1,41 +1,42 @@
 from __future__ import absolute_import
 import netrc
 import os
+import platform
 
-def clear_netrc():
+def netrc_name():
+    if platform.system().lower() == 'windows':
+        return "_netrc"
+    else:
+        return ".netrc"
+
+def get_netrc_file():
     # TODO: support netrc files in locations other than ~/.netrc
+    fname = os.path.join(os.environ['HOME'], netrc_name())
     try:
-        netrc_file = netrc.netrc()
+        netrc_file = netrc.netrc(fname)
     except IOError:
         # if netrc does not exist, touch it
         # from: http://stackoverflow.com/questions/1158076/implement-touch-using-python
-        fname = os.path.join(os.environ['HOME'], ".netrc")
         with open(fname, 'a'):
                 os.utime(fname, None)
-        netrc_file = netrc.netrc()
+        netrc_file = netrc.netrc(fname)
+    
+    return netrc_file, fname
+
+def clear_netrc():
+    netrc_file, fname = get_netrc_file()
 
     del netrc_file.hosts['git.gigalixir.com'] 
     del netrc_file.hosts['api.gigalixir.com']
-    file = os.path.join(os.environ['HOME'], ".netrc")
-    with open(file, 'w') as fp:
+    with open(fname, 'w') as fp:
         fp.write(netrc_repr(netrc_file))
 
 def update_netrc(email, key):
-    # TODO: support netrc files in locations other than ~/.netrc
-    try:
-        netrc_file = netrc.netrc()
-    except IOError:
-        # if netrc does not exist, touch it
-        # from: http://stackoverflow.com/questions/1158076/implement-touch-using-python
-        fname = os.path.join(os.environ['HOME'], ".netrc")
-        with open(fname, 'a'):
-                os.utime(fname, None)
-        netrc_file = netrc.netrc()
+    netrc_file, fname = get_netrc_file()
 
     netrc_file.hosts['git.gigalixir.com'] = (email, None, key)
     netrc_file.hosts['api.gigalixir.com'] = (email, None, key)
-    file = os.path.join(os.environ['HOME'], ".netrc")
-    with open(file, 'w') as fp:
+    with open(fname, 'w') as fp:
         fp.write(netrc_repr(netrc_file))
 
 # Copied from https://github.com/enthought/Python-2.7.3/blob/master/Lib/netrc.py#L105

--- a/gigalixir/openers/windows.py
+++ b/gigalixir/openers/windows.py
@@ -1,0 +1,8 @@
+from gigalixir.shell import cast
+import logging
+
+class WindowsOpener(object):
+    def open(self, url):
+        logging.getLogger("gigalixir-cli").info("Running: start %s" % url)
+        cast("start %s" % url)
+

--- a/gigalixir/routers/darwin.py
+++ b/gigalixir/routers/darwin.py
@@ -27,3 +27,5 @@ rdr pass on lo0 inet proto tcp from any to %s port %s -> 127.0.0.1 port %s
         cast("sudo ifconfig lo0 %s netmask 255.255.255.255 -alias" % ip)
         subprocess.call("sudo pfctl -ef /etc/pf.conf".split())
 
+    def supports_multiplexing():
+        return True

--- a/gigalixir/routers/linux.py
+++ b/gigalixir/routers/linux.py
@@ -13,3 +13,6 @@ class LinuxRouter(object):
         logging.getLogger("gigalixir-cli").info("If prompted, please enter your sudo password:")
         cast("sudo iptables -t nat -D OUTPUT -p all -d %(ip)s -j DNAT --to-destination 127.0.0.1" % {"ip": ip})
         # cast("sudo iptables -t nat -L OUTPUT")
+
+    def supports_multiplexing():
+        return True

--- a/gigalixir/routers/windows.py
+++ b/gigalixir/routers/windows.py
@@ -3,9 +3,14 @@ import logging
 
 class WindowsRouter(object):
     def route_to_localhost(self, ip, epmd_port, distribution_port):
+        # NOTE: Untested as multiplexing not supported on platform
         logging.getLogger("gigalixir-cli").info("Setting up route")
         cast("route ADD %s MASK 255.255.255.255 127.0.0.1" % ip)
 
     def unroute_to_localhost(self, ip):
+        # NOTE: Untested as multiplexing not supported on platform
         logging.getLogger("gigalixir-cli").info("Cleaning up route")
         cast("route delete %s" % ip)
+
+    def supports_multiplexing(self):
+        return False

--- a/gigalixir/routers/windows.py
+++ b/gigalixir/routers/windows.py
@@ -1,0 +1,11 @@
+from gigalixir.shell import cast
+import logging
+
+class WindowsRouter(object):
+    def route_to_localhost(self, ip, epmd_port, distribution_port):
+        logging.getLogger("gigalixir-cli").info("Setting up route")
+        cast("route ADD %s MASK 255.255.255.255 127.0.0.1" % ip)
+
+    def unroute_to_localhost(self, ip):
+        logging.getLogger("gigalixir-cli").info("Cleaning up route")
+        cast("route delete %s" % ip)


### PR DESCRIPTION
This is for https://github.com/gigalixir/gigalixir-cli/issues/28.
Based on the hint you had in that issue I was able to figure it out. Windows thinks .netrc is a file extension so the common solution is to use a _netrc file instead. I also had to add the HOME environment variable since it's not normally set on Windows.

Something I had to do to get it to build was to comment out the git imports since it couldn't find the library. Not sure what I was doing wrong there though. I'm a complete amateur at Python.