### PR TITLE
Update troubleshooting docs for prod.secret.exs

### DIFF
--- a/docs/source/main.rst
+++ b/docs/source/main.rst
@@ -1596,7 +1596,7 @@ A good first thing to try when you get a `git push` error is `cleaning your buil
 
     - failed to connect: ** (Postgrex.Error) FATAL 53300 (too_many_connections): too many connections for database
 
-        - If you have a free tier database, the number of connections is limited. Try lowering the :elixir:`pool_size` in your :bash:`prod.exs` to 2.
+        - If you have a free tier database, the number of connections is limited. Try lowering the :elixir:`pool_size` in your :bash:`prod.exs` to 2, or if you're using :bash:`prod.secret.exs` setting the :bash:`POOL_SIZE` environment variable using :bash:`gigalixir config:set POOL_SIZE=2`.
 
     - ~/.netrc access too permissive: access permissions must restrict access to only the owner
 


### PR DESCRIPTION
@jesseshieh, thanks again for helping out with my problem.  

I thought that it might be nice to have a clarification in the troubleshooting steps.  I think that this change clarifies the difference in using `prod.exs` vs `prod.secret.exs`.

I was also thinking it might make sense to add it ahead of time in the sections `Using Mix`, `Using Elixir` and `Using Distillery`.  Each could be amended as follows:

>As of Phoenix 1.4.4+, `prod.secret.exs` has been [modernized](https://github.com/phoenixframework/phoenix/pull/3380) and uses environment variables for configuration which is exactly what we want.  Just modify the default value for the `pool_size` in `prod.secrets.exs` to `"2"` if you are using a free tier database.
If you are running an older version of phoenix, you'll probably want to delete your `prod.secret.exs` file, and comment out the line in your `prod.exs` that imports it.

Or:

>As of Phoenix 1.4.4+, `prod.secret.exs` has been [modernized](https://github.com/phoenixframework/phoenix/pull/3380) and uses environment variables for configuration which is exactly what we want.  Just be sure to use `gigalixir config:set POOL_SIZE=2` if you are using a free tier database.
If you are running an older version of phoenix, you'll probably want to delete your `prod.secret.exs` file, and comment out the line in your `prod.exs` that imports it.

I think that the troubleshooting update would have been enough to keep me on track, so I only made that change.