### PR TITLE
Add ssh_cmd option to all ssh commands

### DIFF
--- a/gigalixir/__init__.py
+++ b/gigalixir/__init__.py
@@ -326,23 +326,25 @@ def rollback(ctx, app_name, version):
 @cli.command(name='ps:remote_console')
 @click.option('-a', '--app_name')
 @click.option('-o', '--ssh_opts', default="", help='Command-line options to pass to ssh.')
+@click.option('-o', '--ssh_cmd', default="ssh", help='Which ssh command to use.')
 @click.pass_context
 @report_errors
 @detect_app_name
-def remote_console(ctx, app_name, ssh_opts):
+def remote_console(ctx, app_name, ssh_opts, ssh_cmd):
     """
     Drop into a remote console on a live production node.
     """
-    gigalixir_app.remote_console(ctx.obj['host'], app_name, ssh_opts)
+    gigalixir_app.remote_console(ctx.obj['host'], app_name, ssh_opts, ssh_cmd)
 
 @cli.command(name='ps:run')
 @click.option('-a', '--app_name')
 @click.argument('command', nargs=-1)
 @click.option('-o', '--ssh_opts', default="", help='Command-line options to pass to ssh.')
+@click.option('-o', '--ssh_cmd', default="ssh", help='Which ssh command to use.')
 @click.pass_context
 @report_errors
 @detect_app_name
-def ps_run(ctx, app_name, ssh_opts, command):
+def ps_run(ctx, app_name, ssh_opts, ssh_cmd, command):
     """
     Run a shell command on your running container.
     """
@@ -352,27 +354,29 @@ def ps_run(ctx, app_name, ssh_opts, command):
 @click.option('-a', '--app_name')
 @click.argument('command', nargs=-1)
 @click.option('-o', '--ssh_opts', default="", help='Command-line options to pass to ssh.')
+@click.option('-o', '--ssh_cmd', default="ssh", help='Which ssh command to use.')
 @click.pass_context
 @report_errors
 @detect_app_name
-def ssh(ctx, app_name, ssh_opts, command):
+def ssh(ctx, app_name, ssh_opts, ssh_cmd, command):
     """
     Ssh into app. Be sure you added your ssh key using gigalixir create ssh_key. Configs are not loaded automatically.
     """
-    gigalixir_app.ssh(ctx.obj['host'], app_name, ssh_opts, *command)
+    gigalixir_app.ssh(ctx.obj['host'], app_name, ssh_opts, ssh_cmd, *command)
 
 @cli.command(name='ps:distillery')
 @click.option('-a', '--app_name')
 @click.argument('distillery_command', nargs=-1)
 @click.option('-o', '--ssh_opts', default="", help='Command-line options to pass to ssh.')
+@click.option('-o', '--ssh_cmd', default="ssh", help='Which ssh command to use.')
 @click.pass_context
 @report_errors
 @detect_app_name
-def distillery(ctx, app_name, ssh_opts, distillery_command):
+def distillery(ctx, app_name, ssh_opts, ssh_cmd, distillery_command):
     """
     Runs a distillery command to run on the remote container e.g. ping, remote_console. Be sure you've added your ssh key.
     """
-    gigalixir_app.distillery_command(ctx.obj['host'], app_name, ssh_opts, *distillery_command)
+    gigalixir_app.distillery_command(ctx.obj['host'], app_name, ssh_opts, ssh_cmd, *distillery_command)
 
 @cli.command(name='ps:restart')
 @click.option('-a', '--app_name')
@@ -403,14 +407,15 @@ def run(ctx, app_name, command):
 @click.option('-a', '--app_name')
 @click.option('-m', '--migration_app_name', default=None, help='For umbrella apps, specify which inner app to migrate.')
 @click.option('-o', '--ssh_opts', default="", help='Command-line options to pass to ssh.')
+@click.option('-o', '--ssh_cmd', default="ssh", help='Which ssh command to use.')
 @click.pass_context
 @report_errors
 @detect_app_name
-def ps_migrate(ctx, app_name, migration_app_name, ssh_opts):
+def ps_migrate(ctx, app_name, migration_app_name, ssh_opts, ssh_cmd):
     """
     Run Ecto Migrations on a production node.
     """
-    gigalixir_app.migrate(ctx.obj['host'], app_name, migration_app_name, ssh_opts)
+    gigalixir_app.migrate(ctx.obj['host'], app_name, migration_app_name, ssh_opts, ssh_cmd)
 
 # @update.command()
 @cli.command(name='account:payment_method:set')

--- a/gigalixir/app.py
+++ b/gigalixir/app.py
@@ -115,25 +115,25 @@ def customer_app_name(host, app_name):
         data = json.loads(r.text)["data"]
         return data["customer_app_name"]
 
-def distillery_eval(host, app_name, ssh_opts, expression):
+def distillery_eval(host, app_name, ssh_opts, ssh_cmd, expression):
     # capture_output == True as this isn't interactive
     # and we want to return the result as a string rather than
     # print it out to the screen
-    return ssh_helper(host, app_name, ssh_opts, True, "gigalixir_run", "distillery_eval", "--", expression)
+    return ssh_helper(host, app_name, ssh_opts, ssh_cmd, True, "gigalixir_run", "distillery_eval", "--", expression)
 
-def distillery_command(host, app_name, ssh_opts, *args):
-    ssh(host, app_name, ssh_opts, "gigalixir_run", "shell", "--", "bin/%s" % customer_app_name(host, app_name), *args)
+def distillery_command(host, app_name, ssh_opts, ssh_cmd, *args):
+    ssh(host, app_name, ssh_opts, ssh_cmd, "gigalixir_run", "shell", "--", "bin/%s" % customer_app_name(host, app_name), *args)
 
-def ssh(host, app_name, ssh_opts, *args):
+def ssh(host, app_name, ssh_opts, ssh_cmd, *args):
     # capture_output == False for interactive mode which is
     # used by ssh, remote_console, distillery_command
-    ssh_helper(host, app_name, ssh_opts, False, *args)
+    ssh_helper(host, app_name, ssh_opts, ssh_cmd, False, *args)
 
 # if using this from a script, and you want the return
 # value in a variable, use capture_output=True
 # capture_output needs to be False for remote_console
 # and regular ssh to work.
-def ssh_helper(host, app_name, ssh_opts, capture_output, *args):
+def ssh_helper(host, app_name, ssh_opts, ssh_cmd, capture_output, *args):
     # verify SSH keys exist
     keys = ssh_key.ssh_keys(host)
     if len(keys) == 0:
@@ -153,11 +153,11 @@ def ssh_helper(host, app_name, ssh_opts, capture_output, *args):
             escaped_args = [pipes.quote(arg) for arg in args]
             command = " ".join(escaped_args)
             if capture_output:
-                return call("ssh %s -t root@%s %s" % (ssh_opts, ssh_ip, command))
+                return call("%s %s -t root@%s %s" % (ssh_cmd, ssh_opts, ssh_ip, command))
             else:
-                cast("ssh %s -t root@%s %s" % (ssh_opts, ssh_ip, command))
+                cast("%s %s -t root@%s %s" % (ssh_cmd, ssh_opts, ssh_ip, command))
         else:
-            cast("ssh %s -t root@%s" % (ssh_opts, ssh_ip))
+            cast("%s %s -t root@%s" % (ssh_cmd, ssh_opts, ssh_ip))
 
 
 def restart(host, app_name):
@@ -217,18 +217,18 @@ def run(host, app_name, command):
         click.echo("See `gigalixir logs` for any output.")
         click.echo("See `gigalixir ps` for job info.")
 
-def ps_run(host, app_name, ssh_opts, *command):
+def ps_run(host, app_name, ssh_opts, ssh_cmd, *command):
     # runs command in same container app is running
-    ssh(host, app_name, ssh_opts, "gigalixir_run", "shell", "--", *command)
+    ssh(host, app_name, ssh_opts, ssh_cmd, "gigalixir_run", "shell", "--", *command)
 
-def remote_console(host, app_name, ssh_opts):
-    ssh(host, app_name, ssh_opts, "gigalixir_run", "remote_console")
+def remote_console(host, app_name, ssh_opts, ssh_cmd):
+    ssh(host, app_name, ssh_opts, ssh_cmd, "gigalixir_run", "remote_console")
 
-def migrate(host, app_name, migration_app_name, ssh_opts):
+def migrate(host, app_name, migration_app_name, ssh_opts, ssh_cmd):
     if migration_app_name is None:
-        ssh(host, app_name, ssh_opts, "gigalixir_run", "migrate")
+        ssh(host, app_name, ssh_opts, ssh_cmd, "gigalixir_run", "migrate")
     else:
-        ssh(host, app_name, ssh_opts, "gigalixir_run", "migrate", "-m", migration_app_name)
+        ssh(host, app_name, ssh_opts, ssh_cmd, "gigalixir_run", "migrate", "-m", migration_app_name)
 
 def logs(host, app_name, num, no_tail):
     payload = {


### PR DESCRIPTION
After a quick glance at the source I'm trying to add an option to change the default ssh-command ref #52. This is to give control in cases where the user wants a custom ssh command like `kitty +kitten ssh`.
E.g. `gigalixir ps:remote_shell --ssh_cmd "kitty +kitten ssh"`

I haven't gotten the tests to run properly yet.

Maybe this should be added to the config so that you don't have to include it in every command.

