### PR TITLE
Relax dependency requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,12 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'click~=6.7',
-        'requests~=2.20.0',
-        'stripe~=1.51.0',
-        'rollbar~=0.13.11',
-        'pygments~=2.2.0',
-        'qrcode~=6.1',
+        'click>=6.7',
+        'requests>=2.20.0',
+        'stripe>=1.28.0',
+        'rollbar>=0.13.11',
+        'pygments>=2.2.0',
+        'qrcode>=6.1',
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
I'm maintaining [a package for this tool in Arch Linux](https://aur.archlinux.org/packages/gigalixir-cli/). Since the dependencies are maintained as separate Python packages in the Arch package repo, I need this to be compatible with up-to-date package versions. This change relaxes the version requirements to accept higher versions. I'm pretty sure this causes no problems with existing package versions, because the Arch package has been doing this downstream for a while and I've had no problems reported.

I also bumped the lowest stripe version down because until recently, that package was out of date so I happen to know that 1.28.0 works. That change is not necessary, though, as I now have an updated version available (2.55.0, which also works fine).