### PR TITLE
update How to run migrations on startup docs

### DIFF
--- a/docs/source/database.rst
+++ b/docs/source/database.rst
@@ -302,7 +302,7 @@ If you aren't running distillery or elixir releases, meaning you are in mix mode
 
 .. code-block:: bash
 
-    web: mix ecto.migrate && elixir --name $MY_NODE_NAME --cookie $MY_COOKIE -S mix phoenix.server
+    web: mix ecto.migrate && elixir --name $MY_NODE_NAME --cookie $MY_COOKIE -S mix phx.server
 
 For more details, see :ref:`custom procfile`.
 


### PR DESCRIPTION
The 'How to run migrations on startup' with mix give the following error
```
** (Mix) The task "phoenix.server" could not be found. Did you mean "phx.server"? 
```

Edited to use phx.server as suggested.