### PR TITLE
Add documentation for handling multiple SSH keys on your machine

### DIFF
--- a/docs/source/runtime.rst
+++ b/docs/source/runtime.rst
@@ -53,6 +53,10 @@ The :bash:`-o` option lets you pass in arbitrary options to :bash:`ssh`. Somethi
 
     gigalixir ps:ssh -o "-i ~/.ssh/id_rsa"
 
+If you have multiple SSH keys on your machine, you may need to explicitly specify which one the Gigalixir CLI should use when connecting. If you get a :bash:`Permission denied (publickey)` error when attempting to run commands through the CLI but your :bash:`git push gigalixir master` (or equivalent) succeeds, first try specifying the SSH key you want to use with the option above.
+
+You can use :bash:`-o` to specify any option or options to :bash:`ssh`.
+
 .. _`Launching a remote console`:
 .. _`drop into a remote console`:
 .. _`remote console`:


### PR DESCRIPTION
We have the possibility of `Access Denied (publickey)` authentication issues on commands such as `gigalixir ps:migrate`, yet `git push` still succeeds. If this is the case, it is likely (though not guaranteed) that multiple SSH keys are present. The Gigalixir CLI might not auto-select the desired key when multiple keys are present, and the error message presented by the CLi isn't immediately intuitive.

This documentation update provides more clarity on how to identify the issue and then resolve it.