### PR TITLE
Fix docutils error on pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     ],
     extras_require={
         'dev': [
+            'docutils~=0.16.0',
             'Sphinx',
             'sphinx_rtd_theme',
             'sphinx-tabs',


### PR DESCRIPTION
Not sure, but after reading
https://stackoverflow.com/questions/66949028/docutils-dependecy-of-sphinx-theme-on-readthedocs/69166464#69166464

And re-ordering the dependency, this seems to fix it.