### PR TITLE
Fix ValueError I/O operation on closed file

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 testpaths=test
-log_cli = 1
+log_cli = 0
 log_cli_level = INFO
 log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
 log_cli_date_format=%Y-%m-%d %H:%M:%S


### PR DESCRIPTION
Not sure yet, but
https://github.com/pallets/click/issues/824

and then
https://docs.pytest.org/en/6.2.x/logging.html#live-logs

suggested turning this off and it seems to have worked.