### PR TITLE
Fixing observer

### DIFF
--- a/gigalixir/app.py
+++ b/gigalixir/app.py
@@ -120,7 +120,7 @@ def distillery_eval(session, app_name, ssh_opts, ssh_cmd, expression):
     # capture_output == True as this isn't interactive
     # and we want to return the result as a string rather than
     # print it out to the screen
-    return ssh_helper(session, app_name, ssh_opts, ssh_cmd, True, "gigalixir_run", "distillery_eval", "--", expression)
+    return ssh_helper(session, app_name, ssh_opts, ssh_cmd, True, "gigalixir_run", "distillery-eval", "--", expression)
 
 def distillery_command(session, app_name, ssh_opts, ssh_cmd, *args):
     ssh(session, app_name, ssh_opts, ssh_cmd, "gigalixir_run", "shell", "--", "bin/%s" % customer_app_name(session, app_name), *args)


### PR DESCRIPTION
It looks like there is a typo with the ssh_helper command and it is not possible to launch observer. In the code it is `distillery_eval`, but according to the `gigalixir_run --help` command it should be `distillery-eval`. Also tested this locally and it looks to have fixed being able to launch observer.

```
# gigalixir_run --help
Usage: gigalixir_run [OPTIONS] COMMAND [ARGS]...

Options:
  --env TEXT  GIGALIXIR environment [prod, dev].
  --help      Show this message and exit.

Commands:
  bootstrap
  distillery-eval
  distillery-job
  init
  job
  migrate
  remote-console
  remote_console
  run
  shell
  upgrade
```